### PR TITLE
Improve LLM node tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# LLM
-Experiments
+# LLM ComfyUI Nodes
+
+This repository contains an experimental set of custom ComfyUI nodes that expose
+an end-to-end chat language model pipeline. Each step of the generation process
+(prompt creation, probability algebra, token sampling, etc.) is represented as a
+first-class node that can be arranged on the canvas.
+
+The nodes live under `custom_nodes/comfy_llm` and are discovered by ComfyUI via
+the `NODE_CLASS_MAPPINGS` dictionary.
+
+The implementation is intentionally lightweight and relies on HuggingFace
+Transformers for the inference backend. A tiny GPT‑2 model is used by default so
+that the graph can run without large downloads.
+
+## Usage
+
+1. Install the required Python packages:
+
+   ```bash
+   pip install torch transformers
+   ```
+
+2. Start ComfyUI with this repository on the Python path so it can discover the
+   `comfy_llm` nodes.
+
+These nodes are only a prototype but demonstrate how chat-style workflows can be
+assembled entirely from the ComfyUI canvas.
+
+## Tests
+
+The repository includes a small pytest suite covering the math helpers and
+node APIs. After installing the dependencies you can run it with:
+
+```bash
+pytest -q
+```
+
+The tests load the nodes, perform a few sample operations, and verify that
+probabilities remain normalised.

--- a/custom_nodes/comfy_llm/__init__.py
+++ b/custom_nodes/comfy_llm/__init__.py
@@ -1,0 +1,27 @@
+from .nodes import (
+    ChatInput,
+    ChatHistory,
+    PromptBuilder,
+    HFInference,
+    AverageProbs,
+    RatioProbs,
+    TemperatureScaler,
+    TokenSampler,
+    ChatUpdate,
+    TensorViewer,
+    get_classes,
+)
+
+NODE_CLASS_MAPPINGS = {cls.__name__: cls for cls in get_classes()}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "ChatInput": "Chat Input",
+    "ChatHistory": "Chat History",
+    "PromptBuilder": "Prompt Builder",
+    "HFInference": "HF Inference",
+    "AverageProbs": "Average Probs",
+    "RatioProbs": "Ratio Probs",
+    "TemperatureScaler": "Temperature Scaler",
+    "TokenSampler": "Token Sampler",
+    "ChatUpdate": "Chat Update",
+    "TensorViewer": "Tensor Viewer",
+}

--- a/custom_nodes/comfy_llm/nodes.py
+++ b/custom_nodes/comfy_llm/nodes.py
@@ -1,0 +1,260 @@
+# Node implementations for ComfyUI LLM prototype
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+import os
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Simple in-memory conversation store
+_CONVERSATIONS = {}
+
+
+def _get_conv(conv_id: str) -> List[int]:
+    return _CONVERSATIONS.setdefault(conv_id, [])
+
+
+def _append_token(conv_id: str, token_id: int):
+    _get_conv(conv_id).append(token_id)
+
+
+def _tokens_to_markdown(tokens: List[int], tokenizer) -> str:
+    if not tokens:
+        return ""
+    text = tokenizer.decode(tokens)
+    return text
+
+
+class ChatInput:
+    """Receives a user message and optional conversation id."""
+
+    INPUT_TYPES = {
+        "required": {
+            "message": ("STRING", {"forceInput": True}),
+            "conversation_id": ("STRING", {"default": ""}),
+        }
+    }
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("user_msg", "conv_id")
+    CATEGORY = "LLM/IO"
+
+    def execute(self, message: str, conversation_id: str) -> Tuple[str, str]:
+        conv_id = conversation_id or os.urandom(4).hex()
+        return message, conv_id
+
+
+class ChatHistory:
+    """Returns recent conversation as markdown."""
+
+    INPUT_TYPES = {
+        "required": {
+            "conv_id": ("STRING", {"forceInput": True}),
+            "n_turns": ("INT", {"default": 5}),
+        }
+    }
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("history_md",)
+    OUTPUT_NODE = True
+    CATEGORY = "LLM/Display"
+
+    def execute(self, conv_id: str, n_turns: int) -> Tuple[str]:
+        tokens = _get_conv(conv_id)[-n_turns:]
+        tokenizer = AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
+        md = _tokens_to_markdown(tokens, tokenizer)
+        return (md,)
+
+
+class PromptBuilder:
+    """Concatenate system prompt, history, and user message."""
+
+    INPUT_TYPES = {
+        "required": {
+            "system_msg": ("STRING", {}),
+            "history_md": ("STRING", {}),
+            "user_msg": ("STRING", {}),
+        }
+    }
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("prompt",)
+    CATEGORY = "LLM/Pre-proc"
+
+    def execute(self, system_msg: str, history_md: str, user_msg: str) -> Tuple[str]:
+        prompt = f"{system_msg}\n{history_md}\n{user_msg}".strip()
+        return (prompt,)
+
+
+class HFInference:
+    """Run a HF causal LM and return probabilities for next token."""
+
+    INPUT_TYPES = {
+        "required": {
+            "prompt": ("STRING", {"forceInput": True}),
+            "model_name": ("STRING", {"default": os.environ.get("HF_MODEL", "sshleifer/tiny-gpt2")}),
+            "max_new_tokens": ("INT", {"default": 1}),
+        }
+    }
+    RETURN_TYPES = ("TENSOR",)
+    RETURN_NAMES = ("prob_batch",)
+    CATEGORY = "LLM/Model"
+
+    def execute(self, prompt: str, model_name: str, max_new_tokens: int):
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        input_ids = tokenizer.encode(prompt, return_tensors="pt")
+        with torch.no_grad():
+            out = model(input_ids)
+        logits = out.logits[:, -1, :]
+        probs = torch.softmax(logits, dim=-1)
+        return (probs,)
+
+
+class AverageProbs:
+    """Mean of tensors in list."""
+
+    INPUT_TYPES = {
+        "required": {
+            "probs": ("TENSOR", {"forceInput": True, "is_list": True}),
+        }
+    }
+    RETURN_TYPES = ("TENSOR",)
+    RETURN_NAMES = ("avg_probs",)
+    CATEGORY = "LLM/Math"
+    INPUT_IS_LIST = True
+
+    def execute(self, probs: List[torch.Tensor]):
+        stack = torch.stack(probs)
+        avg = stack.mean(dim=0)
+        avg = torch.clamp(avg, min=1e-7)
+        avg = avg / avg.sum(dim=-1, keepdim=True)
+        return (avg,)
+
+
+class RatioProbs:
+    """Element-wise division of tensors with renorm."""
+
+    INPUT_TYPES = {
+        "required": {
+            "positive_probs": ("TENSOR", {"forceInput": True}),
+            "negative_probs": ("TENSOR", {"forceInput": True}),
+            "epsilon": ("FLOAT", {"default": 1e-7}),
+        }
+    }
+    RETURN_TYPES = ("TENSOR",)
+    RETURN_NAMES = ("ratio_probs",)
+    CATEGORY = "LLM/Math"
+
+    def execute(self, positive_probs: torch.Tensor, negative_probs: torch.Tensor, epsilon: float):
+        ratio = positive_probs / (negative_probs + epsilon)
+        ratio = torch.clamp(ratio, min=0)
+        ratio = ratio / ratio.sum(dim=-1, keepdim=True)
+        return (ratio,)
+
+
+class TemperatureScaler:
+    """Adjust logits or probs by temperature."""
+
+    INPUT_TYPES = {
+        "required": {
+            "logits_or_probs": ("TENSOR", {"forceInput": True}),
+            "temperature": ("FLOAT", {"default": 1.0}),
+        }
+    }
+    RETURN_TYPES = ("TENSOR",)
+    RETURN_NAMES = ("scaled",)
+    CATEGORY = "LLM/Math"
+
+    def execute(self, logits_or_probs: torch.Tensor, temperature: float):
+        scaled = logits_or_probs / max(temperature, 1e-5)
+        scaled = torch.softmax(scaled, dim=-1)
+        return (scaled,)
+
+
+class TokenSampler:
+    """Sample token id from probability batch."""
+
+    INPUT_TYPES = {
+        "required": {
+            "prob_batch": ("TENSOR", {"forceInput": True}),
+            "top_k": ("INT", {"default": 50}),
+            "top_p": ("FLOAT", {"default": 0.95}),
+            "seed": ("INT", {"default": None}),
+        }
+    }
+    RETURN_TYPES = ("INT", "FLOAT")
+    RETURN_NAMES = ("token_id", "token_prob")
+    CATEGORY = "LLM/Sampler"
+
+    def execute(self, prob_batch: torch.Tensor, top_k: int, top_p: float, seed: Optional[int]):
+        if seed is not None:
+            torch.manual_seed(seed)
+        probs = prob_batch.squeeze(0)
+        topk_probs, topk_indices = torch.topk(probs, k=top_k)
+        cumulative = torch.cumsum(topk_probs, dim=0)
+        mask = cumulative <= top_p
+        if mask.sum() == 0:
+            mask[0] = True
+        filtered_probs = topk_probs[mask]
+        filtered_indices = topk_indices[mask]
+        filtered_probs = filtered_probs / filtered_probs.sum()
+        dist = torch.distributions.Categorical(filtered_probs)
+        idx = dist.sample()
+        token_id = filtered_indices[idx].item()
+        token_prob = filtered_probs[idx].item()
+        return token_id, token_prob
+
+
+class ChatUpdate:
+    """Append sampled token to conversation."""
+
+    INPUT_TYPES = {
+        "required": {
+            "conv_id": ("STRING", {"forceInput": True}),
+            "token_id": ("INT", {}),
+            "token_prob": ("FLOAT", {}),
+        }
+    }
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("conv_id",)
+    CATEGORY = "LLM/IO"
+
+    def execute(self, conv_id: str, token_id: int, token_prob: float):
+        _append_token(conv_id, token_id)
+        return (conv_id,)
+
+
+class TensorViewer:
+    """Return string slice of tensor for debug."""
+
+    INPUT_TYPES = {
+        "required": {
+            "tensor": ("TENSOR", {"forceInput": True}),
+            "slice_spec": ("STRING", {"default": ":"}),
+        }
+    }
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("text_dump",)
+    CATEGORY = "Debug"
+
+    def execute(self, tensor: torch.Tensor, slice_spec: str) -> Tuple[str]:
+        try:
+            sliced = eval(f"tensor[{slice_spec}]")
+        except Exception:
+            sliced = tensor
+        text = repr(sliced)
+        return (text,)
+
+
+def get_classes():
+    return [
+        ChatInput,
+        ChatHistory,
+        PromptBuilder,
+        HFInference,
+        AverageProbs,
+        RatioProbs,
+        TemperatureScaler,
+        TokenSampler,
+        ChatUpdate,
+        TensorViewer,
+    ]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,62 @@
+import pytest
+
+# Skip tests if torch or transformers not installed properly
+torch = pytest.importorskip('torch')
+transformers = pytest.importorskip('transformers')
+
+from custom_nodes.comfy_llm import nodes
+
+
+def test_average_probs_normalization():
+    t1 = torch.tensor([[0.2, 0.8]])
+    t2 = torch.tensor([[0.5, 0.5]])
+    avg, = nodes.AverageProbs().execute([t1, t2])
+    assert pytest.approx(avg.sum().item()) == 1.0
+
+
+def test_ratio_probs_basic():
+    pos = torch.tensor([[0.6, 0.4]])
+    neg = torch.tensor([[0.2, 0.8]])
+    ratio, = nodes.RatioProbs().execute(pos, neg, 1e-7)
+    assert ratio.min().item() >= 0
+    assert pytest.approx(ratio.sum().item()) == 1.0
+
+
+def test_temperature_scaler_entropy():
+    data = torch.tensor([[1.0, 2.0, 3.0]])
+    scaled, = nodes.TemperatureScaler().execute(data, 0.5)
+    assert pytest.approx(scaled.sum().item()) == 1.0
+
+
+def test_token_sampler_deterministic():
+    probs = torch.tensor([[0.1, 0.9]])
+    sampler = nodes.TokenSampler()
+    t1 = sampler.execute(probs, top_k=2, top_p=1.0, seed=123)
+    t2 = sampler.execute(probs, top_k=2, top_p=1.0, seed=123)
+    assert t1 == t2
+
+
+def test_chat_update_and_history_roundtrip():
+    conv_id = 'convtest'
+    update = nodes.ChatUpdate()
+    update.execute(conv_id, 0, 0.5)
+    history_md, = nodes.ChatHistory().execute(conv_id, 1)
+    assert isinstance(history_md, str)
+
+
+def test_prompt_builder_and_input():
+    msg, conv = nodes.ChatInput().execute("hi", "")
+    prompt, = nodes.PromptBuilder().execute("sys", "hist", msg)
+    assert "sys" in prompt and "hist" in prompt and "hi" in prompt
+
+
+def test_hf_inference_output_shape():
+    prob, = nodes.HFInference().execute("hello", "sshleifer/tiny-gpt2", 1)
+    assert prob.ndim == 2 and prob.size(0) == 1
+    assert pytest.approx(prob.sum().item()) == 1.0
+
+
+def test_tensor_viewer_slice():
+    tensor = torch.arange(10)
+    text, = nodes.TensorViewer().execute(tensor, "5:")
+    assert "5" in text


### PR DESCRIPTION
## Summary
- extend pytest suite with coverage for remaining nodes
- tests now exercise prompt builder, HF inference, and tensor viewer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861120c63c883219fc173778c5f7bfd