### PR TITLE
Use model tokenizer in ChatHistory

### DIFF
--- a/custom_nodes/comfy_llm/nodes.py
+++ b/custom_nodes/comfy_llm/nodes.py
@@ -56,6 +56,10 @@ class ChatHistory:
             "required": {
                 "conv_id": ("STRING", {}),
                 "n_turns": ("INT", {"default": 5}),
+                "model_name": (
+                    "STRING",
+                    {"default": os.environ.get("HF_MODEL", "sshleifer/tiny-gpt2")},
+                ),
             }
         }
     FUNCTION = "execute"
@@ -64,9 +68,9 @@ class ChatHistory:
     OUTPUT_NODE = True
     CATEGORY = "LLM/Display"
 
-    def execute(self, conv_id: str, n_turns: int) -> Tuple[str]:
+    def execute(self, conv_id: str, n_turns: int, model_name: str) -> Tuple[str]:
         tokens = _get_conv(conv_id)[-n_turns:]
-        tokenizer = AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
         md = _tokens_to_markdown(tokens, tokenizer)
         return (md,)
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -59,7 +59,7 @@ def test_chat_update_and_history_roundtrip():
     conv_id = 'convtest'
     update = nodes.ChatUpdate()
     update.execute(conv_id, 0, 0.5)
-    history_md, = nodes.ChatHistory().execute(conv_id, 1)
+    history_md, = nodes.ChatHistory().execute(conv_id, 1, "sshleifer/tiny-gpt2")
     assert isinstance(history_md, str)
 
 
@@ -79,7 +79,7 @@ def test_tensor_viewer_bad_slice():
 
 def test_chat_history_empty():
     conv = "empty_conv"
-    history_md, = nodes.ChatHistory().execute(conv, 1)
+    history_md, = nodes.ChatHistory().execute(conv, 1, "sshleifer/tiny-gpt2")
     assert history_md == ""
 
 


### PR DESCRIPTION
## Summary
- decode ChatHistory tokens with the model's tokenizer
- update tests for new ChatHistory signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611f43bf90832192421a272e343393