### PR TITLE
Improve TensorViewer safety

### DIFF
--- a/custom_nodes/comfy_llm/nodes.py
+++ b/custom_nodes/comfy_llm/nodes.py
@@ -275,9 +275,30 @@ class TensorViewer:
     RETURN_NAMES = ("text_dump",)
     CATEGORY = "Debug"
 
+    def _parse_part(self, part: str):
+        part = part.strip()
+        if part == "":
+            return slice(None)
+        if ":" in part:
+            segments = part.split(":")
+            if len(segments) > 3:
+                raise ValueError("too many slice segments")
+            vals = []
+            for seg in segments:
+                seg = seg.strip()
+                if seg == "":
+                    vals.append(None)
+                else:
+                    vals.append(int(seg))
+            while len(vals) < 3:
+                vals.append(None)
+            return slice(*vals)
+        return int(part)
+
     def execute(self, tensor: torch.Tensor, slice_spec: str) -> Tuple[str]:
         try:
-            sliced = eval(f"tensor[{slice_spec}]")
+            parts = [self._parse_part(p) for p in slice_spec.split(',') if p != '']
+            sliced = tensor[tuple(parts)] if parts else tensor
         except Exception:
             sliced = tensor
         text = repr(sliced)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -73,9 +73,21 @@ def test_tensor_viewer_slice():
 
 
 def test_tensor_viewer_bad_slice():
+    import os
     t = torch.arange(6).reshape(2, 3)
     viewer = nodes.TensorViewer()
-    dump, = viewer.execute(t, "bad")
+    executed = False
+
+    def fake_system(cmd):
+        nonlocal executed
+        executed = True
+        return 0
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(os, "system", fake_system)
+    dump, = viewer.execute(t, "__import__('os').system('echo hi')")
+    monkeypatch.undo()
+    assert not executed
     assert "tensor" in dump.lower()
 
 


### PR DESCRIPTION
## Summary
- avoid `eval` when slicing tensors in `TensorViewer`
- add regression test showing bad input no longer executes code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686127deae488321840efe404aa21885