### PR TITLE
Ensure ChatUpdate returns new list

### DIFF
--- a/custom_nodes/comfy_llm/nodes.py
+++ b/custom_nodes/comfy_llm/nodes.py
@@ -267,8 +267,9 @@ class ChatUpdate:
     CATEGORY = "LLM/IO"
 
     def execute(self, conversation: List[int], token_id: int, token_prob: float):
-        conversation.append(token_id)
-        return (conversation,)
+        new_conv = list(conversation)
+        new_conv.append(token_id)
+        return (new_conv,)
 
 
 class TensorViewer:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -65,6 +65,15 @@ def test_chat_update_and_history_roundtrip():
     assert isinstance(history_md, str)
 
 
+def test_chat_update_returns_new_list():
+    conversation = [1, 2]
+    update = nodes.ChatUpdate()
+    new_conv, = update.execute(conversation, 3, 0.7)
+    assert conversation == [1, 2]
+    assert new_conv == [1, 2, 3]
+    assert new_conv is not conversation
+
+
 def test_tensor_viewer_slice():
     t = torch.arange(6).reshape(2, 3)
     viewer = nodes.TensorViewer()


### PR DESCRIPTION
## Summary
- avoid mutating the conversation in `ChatUpdate`
- add regression test verifying `ChatUpdate` returns a new list

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686238b1997c83219763aaafc0910a5a